### PR TITLE
fix: China is not showing number of contributors

### DIFF
--- a/template/map.svg
+++ b/template/map.svg
@@ -7489,12 +7489,10 @@
      transform="translate(-1.5631002,-488.5008)">
     <title
        id="title8623">China<!-- cn_contributions -->
-</title>
+    </title>
     <g
        id="cnx"
        class="landxx coastxx cn cnx">
-      <title
-         id="title8625">China, People's Republic of</title>
       <path
          id="path2708"
          class="landxx cn cnx"


### PR DESCRIPTION
There was two names for China, I removed one of the since having both of them is not letting the number of contributions be visible on the map. 